### PR TITLE
Fix documentation

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -89,10 +89,10 @@ open class WSTagsField: UIScrollView {
     fileprivate var intrinsicContentHeight: CGFloat = 0.0
 
     // MARK: - Events
-    /// Called when the text field begins editing.
+    /// Called when the text field ends editing.
     open var onDidEndEditing: ((WSTagsField) -> Void)?
 
-    /// Called when the text field ends editing.
+    /// Called when the text field begins editing.
     open var onDidBeginEditing: ((WSTagsField) -> Void)?
 
     /// Called when the text field should return.


### PR DESCRIPTION
Documentation of `onDidEndEditing` and `onDidBeginEditing` was switched.
This commit includes the fix.