### PR TITLE
Delete backwards fix

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -89,10 +89,10 @@ open class WSTagsField: UIScrollView {
     fileprivate var intrinsicContentHeight: CGFloat = 0.0
 
     // MARK: - Events
-    /// Called when the text field begins editing.
+    /// Called when the text field ends editing.
     open var onDidEndEditing: ((WSTagsField) -> Void)?
 
-    /// Called when the text field ends editing.
+    /// Called when the text field begins editing.
     open var onDidBeginEditing: ((WSTagsField) -> Void)?
 
     /// Called when the text field should return.

--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -529,6 +529,15 @@ extension WSTagsField: UITextFieldDelegate {
 
     public func textField(_ textField: UITextField,
                           shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+
+        /** Discussion
+        * if delimiter.isEmpty, the deleteBackward() action will tokenize the text
+        * the delete backwards key invoces a replacement with an empty string and a range.length = selection.length
+        */
+        if delimiter.isEmpty && string.isEmpty && range.length > 0 {
+          return true
+        }
+
         if string == delimiter {
             tokenizeTextFieldText()
             return false


### PR DESCRIPTION
If the delimiter is left to it's default value (""),
the Keyboards delete button will tokenize the text field's text
A discussion is added to explain the bug and the code