### PR TITLE
TagViews cornerRadius

### DIFF
--- a/Example/WSTagsFieldExample/ViewController.swift
+++ b/Example/WSTagsFieldExample/ViewController.swift
@@ -23,6 +23,7 @@ class ViewController: UIViewController {
         tagsField.frame = tagsView.bounds
         tagsField.returnKeyType = .next
         tagsField.delimiter = " "
+        tagsField.tagCornerRadius = 3.0
 
         tagsField.placeholderAlwayVisible = true
         tagsField.maxHeight = 100.0

--- a/Source/WSTagView.swift
+++ b/Source/WSTagView.swift
@@ -32,6 +32,13 @@ open class WSTagView: UIView {
         }
     }
 
+    open var cornerRadius: CGFloat = 3.0 {
+        didSet {
+            self.layer.cornerRadius = cornerRadius
+            setNeedsDisplay()
+        }
+    }
+
     open override var tintColor: UIColor! {
         didSet { updateContent(animated: false) }
     }
@@ -67,7 +74,7 @@ open class WSTagView: UIView {
     public init(tag: WSTag) {
         super.init(frame: CGRect.zero)
         self.backgroundColor = tintColor
-        self.layer.cornerRadius = 3.0
+        self.layer.cornerRadius = cornerRadius
         self.layer.masksToBounds = true
 
         textColor = .white

--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -50,6 +50,10 @@ open class WSTagsField: UIScrollView {
         didSet { tagViews.forEach { $0.displayDelimiter = self.displayDelimiter ? self.delimiter : "" } }
     }
 
+    open var tagCornerRadius: CGFloat = 3.0 {
+        didSet { tagViews.forEach { $0.cornerRadius = self.tagCornerRadius } }
+    }
+
     open var fieldTextColor: UIColor? {
         didSet { textField.textColor = fieldTextColor }
     }
@@ -198,6 +202,7 @@ open class WSTagsField: UIScrollView {
         tagView.selectedColor = self.selectedColor
         tagView.selectedTextColor = self.selectedTextColor
         tagView.displayDelimiter = self.displayDelimiter ? self.delimiter : ""
+        tagView.cornerRadius = self.tagCornerRadius
 
         tagView.onDidRequestSelection = { [weak self] tagView in
             self?.selectTagView(tagView, animated: true)


### PR DESCRIPTION
`cornerRadius` of WSTagView is not configurable.
Added property to set value through `WSTagsField`.
```swift
let tagsField = WSTagsField()
tagsField.tagCornerRadius = 6.0
```