### PR TITLE
Add an option to stop WSTagsField from becoming scrollable

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -75,6 +75,9 @@ open class WSTagsField: UIScrollView {
             repositionViews()
         }
     }
+    
+    /// Whether or not the WSTagsField should become scrollable
+    open var enableScrolling: Bool = true
 
     @available(*, unavailable, message: "Use 'cornerRadius' instead.")
     open var tagCornerRadius: CGFloat = 3.0
@@ -697,7 +700,9 @@ extension WSTagsField {
             oldIntrinsicContentHeight = newIntrinsicContentHeight
         }
 
-        self.isScrollEnabled = contentRect.height + contentInset.top + contentInset.bottom >= newIntrinsicContentHeight
+        if self.enableScrolling {        
+            self.isScrollEnabled = contentRect.height + contentInset.top + contentInset.bottom >= newIntrinsicContentHeight
+        }
         self.contentSize.width = self.bounds.width - contentInset.left - contentInset.right
         self.contentSize.height = contentRect.height
 


### PR DESCRIPTION
This is to prevent the WSTagsField from stealing touches from another UIScrollView when it's embedded in a scrollable view, such as a long form.

Apologies if I've missed a reason this wouldn't work.