### PR TITLE
Always remove KVO observers

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -276,8 +276,9 @@ open class WSTagsField: UIScrollView {
     }
 
     deinit {
-        if ProcessInfo.processInfo.operatingSystemVersion.majorVersion < 11, let observer = layerBoundsObserver {
+        if let observer = layerBoundsObserver {
             removeObserver(observer, forKeyPath: "layer.bounds")
+            observer.invalidate()
         }
     }
 


### PR DESCRIPTION
Possible fix of `KVO_IS_RETAINING_ALL_OBSERVERS_OF_THIS_OBJECT_IF_IT_CRASHES_AN_OBSERVER_WAS_OVERRELEASED_OR_SMASHED` crash.

#101 & #103