### PR TITLE
Fix iOS 13 crash

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -296,9 +296,15 @@ open class WSTagsField: UIScrollView {
     }
 
     deinit {
-        if let observer = layerBoundsObserver {
-            removeObserver(observer, forKeyPath: "layer.bounds")
-            observer.invalidate()
+        if #available(iOS 13, *) {
+            // Observers should becleared when NSKeyValueObservation is deallocated.
+            // Let's justkeep the code for older iOS versions unmodified to make
+            // sure we don't break anything.
+        } else {
+            if let observer = layerBoundsObserver {
+                removeObserver(observer, forKeyPath: "layer.bounds")
+                observer.invalidate()
+            }
         }
     }
 

--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -297,8 +297,8 @@ open class WSTagsField: UIScrollView {
 
     deinit {
         if #available(iOS 13, *) {
-            // Observers should becleared when NSKeyValueObservation is deallocated.
-            // Let's justkeep the code for older iOS versions unmodified to make
+            // Observers should be cleared when NSKeyValueObservation is deallocated.
+            // Let's just keep the code for older iOS versions unmodified to make
             // sure we don't break anything.
         } else {
             if let observer = layerBoundsObserver {


### PR DESCRIPTION
`WSTagsField` crashes on iOS 13 with line `removeObserver(observer, forKeyPath: "layer.bounds")`. This should not be necessary at all.

Steps to reproduce
- Install Xcode 11, open the project and run unit tests - all will fail
- Install Xcode 11, open the project, run the example
  - Open that modal view controller and close it again - the example will crash