### PR TITLE
Add "context" property to WSTag

### DIFF
--- a/Source/WSTag.swift
+++ b/Source/WSTag.swift
@@ -11,13 +11,15 @@ import Foundation
 public struct WSTag: Hashable {
 
     public let text: String
+    public let context: AnyHashable?
 
-    public init(_ text: String) {
+    public init(_ text: String, context: AnyHashable? = nil) {
         self.text = text
+        self.context = context
     }
 
     public func equals(_ other: WSTag) -> Bool {
-        return self.text == other.text
+        return self.text == other.text && self.context == other.context
     }
 
 }


### PR DESCRIPTION
Hey there 👋

This change would allow the consumer of `WSTag` to attach an arbitrary `Hashable` before calling `addTag(_ tag: WSTag)`. This could be used to more easily support a "Mail" or "Calendar" style email address field, where the display text  of the tag can mix literal email addresses with contact names.

It's a non-breaking change, no code changes should be required of existing users. All the tests pass locally.

Anyway, just thought this could be a useful change to upstream and thought I'd open a PR. (This one shouldn't take too long to read through 😉)