### PR TITLE
Allow multiple options for accepting a tag

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -794,7 +794,7 @@ extension WSTagsField: UITextFieldDelegate {
         if let onShouldAcceptTag = onShouldAcceptTag, !onShouldAcceptTag(self) {
             return false
         }
-        if !isTextFieldEmpty, acceptTagOption == .return {
+        if !isTextFieldEmpty, acceptTagOption.contains(.return) {
             tokenizeTextFieldText()
             return true
         }
@@ -802,11 +802,11 @@ extension WSTagsField: UITextFieldDelegate {
     }
 
     public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if acceptTagOption == .comma && string == "," && onShouldAcceptTag?(self) ?? true {
+        if acceptTagOption.contains(.comma) && string == "," && onShouldAcceptTag?(self) ?? true {
             tokenizeTextFieldText()
             return false
         }
-        if acceptTagOption == .space && string == " " && onShouldAcceptTag?(self) ?? true {
+        if acceptTagOption.contains(.space) && string == " " && onShouldAcceptTag?(self) ?? true {
             tokenizeTextFieldText()
             return false
         }

--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -8,10 +8,16 @@
 
 import UIKit
 
-public enum WSTagAcceptOption {
-    case `return`
-    case comma
-    case space
+public struct WSTagAcceptOption: OptionSet {
+    public let rawValue: Int
+
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    static let `return` = WSTagAcceptOption(rawValue: 1 << 0)
+    static let  comma   = WSTagAcceptOption(rawValue: 1 << 1)
+    static let  space   = WSTagAcceptOption(rawValue: 1 << 2)
 }
 
 open class WSTagsField: UIScrollView {

--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -15,9 +15,9 @@ public struct WSTagAcceptOption: OptionSet {
         self.rawValue = rawValue
     }
 
-    static let `return` = WSTagAcceptOption(rawValue: 1 << 0)
-    static let  comma   = WSTagAcceptOption(rawValue: 1 << 1)
-    static let  space   = WSTagAcceptOption(rawValue: 1 << 2)
+    public static let `return` = WSTagAcceptOption(rawValue: 1 << 0)
+    public static let  comma   = WSTagAcceptOption(rawValue: 1 << 1)
+    public static let  space   = WSTagAcceptOption(rawValue: 1 << 2)
 }
 
 open class WSTagsField: UIScrollView {


### PR DESCRIPTION
This pull request allows clients to select multiple WSTagAcceptOption, for example both return and space options.