### PR TITLE
Added `targetInputField` on `WSTagsField`

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -348,6 +348,10 @@ open class WSTagsField: UIScrollView {
         self.textField.resignFirstResponder()
     }
 
+    public var targetInputField: UITextField {
+        textField
+    }
+
     open override func reloadInputViews() {
         self.textField.reloadInputViews()
     }

--- a/WSTagsField.podspec
+++ b/WSTagsField.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WSTagsField"
-  s.version          = "5.2.0"
+  s.version          = "5.2.1"
   s.summary          = "An iOS text field that represents different Tags"
   s.homepage         = "https://github.com/whitesmith/WSTagsField"
   s.license          = 'MIT'


### PR DESCRIPTION
* Provides a getter for `textField` without leaking the internal `BackspaceDetectingTextField` type.
* Useful for cases where access to the target text field is required, like when using `WSTagsField` in conjunction with other libraries. An example of this would be if using `IQKeyboardManager`. This addition allows us to set keyboard target actions; e.g. `targetInputField.keyboardToolbar.doneBarButton.setTarget(target, action: action)`.