### PR TITLE
Miscalculation of `isScrollEnabled`

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -744,7 +744,7 @@ extension WSTagsField {
         }
 
         if self.enableScrolling {
-            self.isScrollEnabled = contentRect.height + contentInset.top + contentInset.bottom >= newIntrinsicContentHeight
+            self.isScrollEnabled = contentRect.height + contentInset.top + contentInset.bottom > newIntrinsicContentHeight
         }
         self.contentSize.width = self.bounds.width - contentInset.left - contentInset.right
         self.contentSize.height = contentRect.height

--- a/WSTagsField.podspec
+++ b/WSTagsField.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "WSTagsField"
-  s.version          = "5.2.0"
+  s.version          = "5.2.1"
   s.summary          = "An iOS text field that represents different Tags"
   s.homepage         = "https://github.com/whitesmith/WSTagsField"
   s.license          = 'MIT'


### PR DESCRIPTION
  * Corrected calculation of `isScrollEnabled`. Fixes issue where tags can (incorrectly) be scrollable.
  * Issue was seen when using the event `onDidChangeHeightTo` to dynamically update the height constraint on a wrapping view that grows to encompass the size required when new tags are added/removed.