### PR TITLE
Tokenize text field in textFieldDidEndEditing

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -66,6 +66,9 @@ open class WSTagsField: UIScrollView {
             tagViews.forEach { $0.displayDelimiter = self.isDelimiterVisible ? self.delimiter : "" }
         }
     }
+    
+    /// Whether the text field should tokenize strings automatically when the keyboard is dismissed. 
+    open var shouldTokenizeAfterResigningFirstResponder: Bool = false
 
     open var maxHeight: CGFloat = CGFloat.infinity {
         didSet {
@@ -794,7 +797,7 @@ extension WSTagsField: UITextFieldDelegate {
     }
 
     public func textFieldDidEndEditing(_ textField: UITextField) {
-        if !isTextFieldEmpty{
+        if !isTextFieldEmpty, shouldTokenizeAfterResigningFirstResponder {
             tokenizeTextFieldText()
         }
         textDelegate?.textFieldDidEndEditing?(textField)

--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -794,6 +794,9 @@ extension WSTagsField: UITextFieldDelegate {
     }
 
     public func textFieldDidEndEditing(_ textField: UITextField) {
+        if !isTextFieldEmpty{
+            tokenizeTextFieldText()
+        }
         textDelegate?.textFieldDidEndEditing?(textField)
     }
 


### PR DESCRIPTION
The purpose of this PR is tokenize the text that is in the text field after the text field resigns its first responder status.