### PR TITLE
Changed access to tagViews to open to allow manipulation of specific tags views, i.e. tintColor

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -210,7 +210,7 @@ open class WSTagsField: UIScrollView {
     }
 
     open fileprivate(set) var tags = [WSTag]()
-    internal var tagViews = [WSTagView]()
+    open var tagViews = [WSTagView]()
 
     // MARK: - Events
 


### PR DESCRIPTION
After adding tags to tagsField, is now possible to call tagsField.tagViews.first?.tintColor = .red and have the first element with a different color from the others.