### PR TITLE
Placeholder Add Attributes

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -776,14 +776,17 @@ extension WSTagsField {
     }
 
     private func attributedPlaceholder() -> NSAttributedString {
-        var attributes: [NSAttributedString.Key: Any]?
+        let attributedString = NSMutableAttributedString(string: placeholder)
+        
         if let placeholderColor = placeholderColor {
-            attributes = [NSAttributedString.Key.foregroundColor: placeholderColor]
+            attributedString.addAttribute(NSAttributedString.Key.foregroundColor, value: placeholderColor, range: NSMakeRange(0, placeholder.count))
         }
+        
         if let placeholderFont = placeholderFont {
-            attributes = [NSAttributedString.Key.font: placeholderFont]
+            attributedString.addAttribute(NSAttributedString.Key.font, value: placeholderFont, range: NSMakeRange(0, placeholder.count))
         }
-        return NSAttributedString(string: placeholder, attributes: attributes)
+        
+        return attributedString
     }
 
     private var maxHeightBasedOnNumberOfLines: CGFloat {


### PR DESCRIPTION
- Resolved issue where if placeholder font and placeholder color were both modified by user, the placeholder color would be removed from the attributes
- This occured because the attributes variable was being assigned the foreground color and then it was assigned the font, so the foreground color was not saved
- Using addAttributes function on placeholder instead to ensure both attributes are applied