### PR TITLE
Add missing begin/end editing delegate calls

### DIFF
--- a/Source/WSTagsField.swift
+++ b/Source/WSTagsField.swift
@@ -804,10 +804,17 @@ extension WSTagsField {
 }
 
 extension WSTagsField: UITextFieldDelegate {
+    public func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        textDelegate?.textFieldShouldBeginEditing?(textField) ?? true
+    }
 
     public func textFieldDidBeginEditing(_ textField: UITextField) {
         textDelegate?.textFieldDidBeginEditing?(textField)
         unselectAllTagViewsAnimated(true)
+    }
+    
+    public func textFieldShouldEndEditing(_ textField: UITextField) -> Bool {
+        textDelegate?.textFieldShouldEndEditing?(textField) ?? true
     }
 
     public func textFieldDidEndEditing(_ textField: UITextField) {


### PR DESCRIPTION
One of the apps I'm working on needed to show a specific picker instead of opening regular keyboard input. There might be more use cases where we want to disable text input (ie. until some other condition is met).