### PR TITLE
Give developer chance to deal with pasted content

### DIFF
--- a/Example/WSTagsFieldExample/ViewController.swift
+++ b/Example/WSTagsFieldExample/ViewController.swift
@@ -128,6 +128,13 @@ extension ViewController {
         tagsField.onShouldAcceptTag = { field in
             return field.text != "OMG"
         }
+
+        tagsField.onPaste = { [weak self] text, newText in
+            print("Paste \(text)")
+            let tags = newText.components(separatedBy: " ")
+            self?.tagsField.addTags(tags)
+            return true
+        }
     }
 
 }


### PR DESCRIPTION
I want to allow users to paste bunch of tags into a WSTagsField in my project, like "Apple Pear Banana". onDidChangeText isn't enough to check if the content is coming from pasteboard or not for this use case.